### PR TITLE
Update BiotechApparel.xml

### DIFF
--- a/1.5/Mods/CE/Patches/BiotechApparel.xml
+++ b/1.5/Mods/CE/Patches/BiotechApparel.xml
@@ -73,10 +73,9 @@
 						Defs/ThingDef[defName="pphhyy_M3PatternTechArmor"]/equippedStatOffsets/MeleeHitChance</xpath>
 				</li>
 
-				<li Class="PatchOperationAdd">
+				<li Class="PatchOperationAddModExtension">
 					<xpath>Defs/ThingDef[defName="pphhyy_M3PatternTechArmor"]</xpath>
 					<value>
-						<modExtensions Inherit="False">
 							<li Class="CombatExtended.PartialArmorExt">
 								<stats>
 									<li>
@@ -119,7 +118,6 @@
 									</li>
 								</stats>
 							</li>
-						</modExtensions>
 					</value>
 				</li>
 


### PR DESCRIPTION
Fixed error with ModExtentions for M3PatternTechArmor. it was using PatchOperatingAdd and  trying to add to a ModExtension that was not being inherited. Changing to just use OperationAddModExtension and removing the inherit fixed the error.