### PR TITLE
Update BiotechWeapons.xml

### DIFF
--- a/1.5/Mods/CE/Patches/BiotechWeapons.xml
+++ b/1.5/Mods/CE/Patches/BiotechWeapons.xml
@@ -65,7 +65,7 @@
                         <recoilAmount>0.92</recoilAmount>
                         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
                         <hasStandardCommand>true</hasStandardCommand>
-                        <defaultProjectile>Ammo_10x24mmCharged</defaultProjectile>
+                        <defaultProjectile>Bullet_10x24mmCharged</defaultProjectile>
                         <warmupTime>1.3</warmupTime>
                         <range>62</range>
                         <soundCast>ChargeLance_Fire</soundCast>
@@ -78,15 +78,13 @@
                         <ammoSet>AmmoSet_10x24mmCharged</ammoSet>
                     </AmmoUser>
                     <FireModes>
-                        <aimedBurstShotCount>3</aimedBurstShotCount>
-                        <aiUseBurstMode>TRUE</aiUseBurstMode>
+
                         <aiAimMode>AimedShot</aiAimMode>
                     </FireModes>
                     <weaponTags>
                         <li>CE_AI_Rifle</li>
                         <li>AdvancedGun</li>
                     </weaponTags>
-                    <researchPrerequisite>ChargedShot</researchPrerequisite>
                 </li>
 
                 <li Class="PatchOperationReplace">
@@ -122,7 +120,7 @@
                         <recoilAmount>1.50</recoilAmount>
                         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
                         <hasStandardCommand>true</hasStandardCommand>
-                        <defaultProjectile>Ammo_10x24mmCharged</defaultProjectile>
+                        <defaultProjectile>Bullet_10x24mmCharged</defaultProjectile>
                         <warmupTime>1.1</warmupTime>
                         <range>55</range>
                         <burstShotCount>6</burstShotCount>
@@ -161,7 +159,7 @@
                         <recoilAmount>1.50</recoilAmount>
                         <verbClass>CombatExtended.Verb_ShootCE</verbClass>
                         <hasStandardCommand>true</hasStandardCommand>
-                        <defaultProjectile>Ammo_10x24mmCharged</defaultProjectile>
+                        <defaultProjectile>Bullet_10x24mmCharged</defaultProjectile>
                         <warmupTime>1.1</warmupTime>
                         <range>32</range>
                         <burstShotCount>6</burstShotCount>


### PR DESCRIPTION
Fixed Charge Lance not showing up in Tier 2 tech, and fixed the item cards for the three Biotech specific weapons because their projectiles were set to the AmmoSet_ and not Bullet_